### PR TITLE
Fixes Content-Type in responses

### DIFF
--- a/payid-stack.yaml
+++ b/payid-stack.yaml
@@ -87,7 +87,7 @@ Resources:
       Description: "API Gateway endpoints to invoke PayID Lambda"
 
   apiGatewayPayIdResource:
-    Type: 'AWS::ApiGateway::Resource'
+    Type: "AWS::ApiGateway::Resource"
     Properties:
       RestApiId: !Ref apiGateway
       ParentId: !GetAtt
@@ -141,8 +141,8 @@ Resources:
   apiGatewayDomainResourceMapping:
     Type: "AWS::ApiGateway::BasePathMapping"
     DependsOn:
-    - "apiGatewayDeployment"
-    - "apiGatewayCustomDomain"
+      - "apiGatewayDeployment"
+      - "apiGatewayCustomDomain"
     Properties:
       DomainName: !Ref "domainName"
       RestApiId: !Ref "apiGateway"
@@ -245,7 +245,6 @@ Resources:
                 Resource:
                   - "*"
           PolicyName: "create-test-account-s3"
-
 
   writeTestAccountToS3:
     Type: "Custom::writeTestAccountToS3Fn"
@@ -362,8 +361,11 @@ Resources:
                       };
                   }
 
+                  const addressFoundResponse = {...successResponse }
+                  addressFoundResponse.headers['Content-Type'] = acceptHeader;
+
                   return {
-                      ...successResponse,
+                      ...addressFoundResponse,
                       body: JSON.stringify({
                           addresses: [selectedAddress],
                           payId: fullPayId


### PR DESCRIPTION
## High Level Overview of Change
The response should be the same Content-Type as the request if it succeeds: https://github.com/payid-org/payid/blob/master/src/middlewares/payIds.ts#L105
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Trying to resolve lambda PayIDs on xpring.io failed. It was because the SDK expects the `Content-Type` to correspond to the address returned instead of `application/json`
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
Requests for single addresses have the correct Content-Type in their responses
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Go to https://payidvalidator.com/ and test your payid
It should still work
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
