### PR TITLE
HTTP method POST is not needed for current functionality

### DIFF
--- a/payid-stack.yaml
+++ b/payid-stack.yaml
@@ -264,7 +264,7 @@ Resources:
 
           const responseHeaders = {
               'Access-Control-Allow-Origin': '*',
-              'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+              'Access-Control-Allow-Methods': 'GET, OPTIONS',
               'Access-Control-Allow-Headers': 'PayID-Version',
               'Access-Control-Expose-Headers': 'PayID-Version, PayID-Server-Version',
               'Cache-Control': 'no-store',


### PR DESCRIPTION
## High Level Overview of Change

The HTTP method POST is not needed with the current functionality. 

### Context of Change

Adjustment of the Access-Control-Allow-Methods header value.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)