### PR TITLE
Adding support for verified address PayID responses

### DIFF
--- a/payid-stack.yaml
+++ b/payid-stack.yaml
@@ -458,6 +458,30 @@ Resources:
             DNSName: !GetAtt "apiGatewayCustomDomain.DistributionDomainName"
             HostedZoneId: !GetAtt "apiGatewayCustomDomain.DistributionHostedZoneId"
 
+  cloudwatchLogsLogGroupListCertificatesFn:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${listCertificatesFn}"
+      RetentionInDays: 7
+    DependsOn:
+      - listCertificatesFn
+
+  cloudwatchLogsLogGroupWriteTestAccountToS3Fn:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${writeTestAccountToS3Fn}"
+      RetentionInDays: 7
+    DependsOn:
+      - writeTestAccountToS3Fn
+
+  cloudwatchLogsLogGroupPayIdServerLambdaFunction:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${payIdServerLambdaFunction}"
+      RetentionInDays: 7
+    DependsOn:
+      - payIdServerLambdaFunction
+
 Outputs:
   apiGatewayBaseURL:
     Value: !Sub "https://${apiGateway}.execute-api.${AWS::Region}.amazonaws.com/"


### PR DESCRIPTION
## High Level Overview of Change

Modified the Lambda function to also return verified addresses as part of the response.

### Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Before / After

Prior to this change the response payload would only include classic PayID addresses. With this change the payload also can contain verified addresses.

## Test Plan

I modified the JSON file uploaded to the S3 bucket to also include verified addresses in addition to classic addresses. 